### PR TITLE
Fixed delete associations

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -1,4 +1,5 @@
 class Client < ApplicationRecord
   # note plural here even if model is singular 
-  has_many :invoices
+  # - also, associated invoices are destroyed when client is destroyed
+  has_many :invoices, dependent: :destroy
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,6 +1,6 @@
 class Invoice < ApplicationRecord
-  # a client gets deleted, assc. record is destroyed
-  belongs_to :client, dependent: :destroy
+  belongs_to :client
 
-  has_many :invoice_items
+  # associated invoice_items are destroyed when invoice is destroyed
+  has_many :invoice_items, dependent: :destroy
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -1,4 +1,3 @@
 class InvoiceItem < ApplicationRecord
-  # an invoice gets deleted, assc. invoice_item is destroyed
-  belongs_to :invoice, dependent: :destroy
+  belongs_to :invoice
 end

--- a/db/migrate/20230302161235_create_invoices.rb
+++ b/db/migrate/20230302161235_create_invoices.rb
@@ -1,7 +1,7 @@
 class CreateInvoices < ActiveRecord::Migration[7.0]
   def change
     create_table :invoices do |t|
-      t.references :client, null: false, foreign_key: {on_delete: :cascade}
+      t.references :client, null: false
 
       t.timestamps
     end

--- a/db/migrate/20230302162730_create_invoice_items.rb
+++ b/db/migrate/20230302162730_create_invoice_items.rb
@@ -1,7 +1,7 @@
 class CreateInvoiceItems < ActiveRecord::Migration[7.0]
   def change
     create_table :invoice_items do |t|
-      t.belongs_to :invoice, null: false, foreign_key: {on_delete: :cascade}
+      t.belongs_to :invoice, null: false
       t.string :service
       t.integer :quantity
       t.decimal :price, precision: 10, scale: 2


### PR DESCRIPTION
# Main Changes
- Applied delete cascade behaviour on `ActiveRecord::Base` level rather than database level at `ActiveRecord::Migration`
- I found that this plays better w/ recycling seed data :)

When I applied the cascading deletion away from the db level, I have found that `bin/rails db:seed` works better! In that I don't have to drop the database altogether to reset the state of the database.

